### PR TITLE
fix github_token error & switch branch fail

### DIFF
--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Check out repository content
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Run YAML Lint
         uses: github/super-linter@v4
@@ -17,3 +19,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_YAML: true
           YAML_LINTER_RULES_PATH: .github/workflows/.yamllint
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The fetch-depth: 0 option was added to the checkout step to ensure that the entire git history is fetched, not just the latest commit. This is important for linters that may need access to the full commit history.

The GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} environment variable was added to the linter step to authenticate the workflow with GitHub. This allows linter to post status checks and comments on pull requests, and ensures the workflow has the necessary permissions to run in the repository context.