### PR TITLE
Fix 3 critical answer errors

### DIFF
--- a/data/1_Orchestration/mount_volumes.yaml
+++ b/data/1_Orchestration/mount_volumes.yaml
@@ -63,13 +63,13 @@ questions:
     help: https://docs.docker.com/storage/volumes/#when-to-use-volumes
 
   - uuid: 7041ae89-e857-4c8c-93a6-418d8e7cfb79
-    question: Which flag must be used to mount a volume subdirectory?
+    question: Which flag syntax is used to mount a volume with specific options such as read-only access?
     answers:
-      - { value: 'subdir', correct: false }
-      - { value: 'volume-subpath', correct: true }
-      - { value: 'mount-dir', correct: false }
-      - { value: 'submount', correct: false }
-    help: https://docs.docker.com/storage/volumes/#mount-a-volume-subdirectory
+      - { value: '--volume-options ro', correct: false }
+      - { value: '--mount type=volume,source=myvolume,target=/data,readonly', correct: true }
+      - { value: '--mount-dir /data --readonly', correct: false }
+      - { value: '--volume-ro myvolume:/data', correct: false }
+    help: https://docs.docker.com/storage/volumes/#syntax
 
   - uuid: e1ff04e7-3483-4bc2-b8c2-f8a67e85b258
     question: Which command creates a named volume that uses the NFS driver with custom mount options?

--- a/data/2_Image_creation_management_registry/push_an_image_to_a_registry.yaml
+++ b/data/2_Image_creation_management_registry/push_an_image_to_a_registry.yaml
@@ -31,9 +31,9 @@ questions:
     answers:
       - { value: 'Docker always signs images', correct: false }
       - { value: 'Image signing is not supported', correct: false }
-      - { value: 'Docker Content Trust is enabled unless explicitly disabled', correct: true }
+      - { value: 'Docker Content Trust is disabled by default and must be enabled via DOCKER_CONTENT_TRUST=1', correct: true }
       - { value: 'Signing is enabled only with Docker EE', correct: false }
-    help: https://docs.docker.com/reference/cli/docker/image/push/#options
+    help: https://docs.docker.com/engine/security/trust/
 
   - uuid: cb4190c0-dad0-4e15-b028-92f7e5be63e1
     question: What happens when you press `CTRL-C` during a `docker image push`?

--- a/data/2_Image_creation_management_registry/single_layer.yaml
+++ b/data/2_Image_creation_management_registry/single_layer.yaml
@@ -1,12 +1,12 @@
 questions:
   - uuid: 5f3ac20f-5ae4-40e5-9fa7-bcb3eaac4ea2
-    question: Which technique allows reducing a Docker image to a single final useful layer?
+    question: Which Docker build option squashes all layers of an image into a single layer?
     answers:
-      - { value: 'Use the --squash option by default', correct: false }
+      - { value: 'docker build --flatten', correct: false }
       - { value: 'Push the image to a private registry', correct: false }
-      - { value: 'Use a multi-stage build', correct: true }
-      - { value: 'Enable content trust', correct: false }
-    help: https://docs.docker.com/develop/develop-images/multistage-build/
+      - { value: 'docker build --squash', correct: true }
+      - { value: 'Use a multi-stage build', correct: false }
+    help: https://docs.docker.com/engine/reference/commandline/build/#squash-an-image
 
   - uuid: f2cbe39d-8e84-46d2-9434-d6b00b40c517
     question: Which command creates an image with layers squashed (merged) together?


### PR DESCRIPTION
## Summary
- Fix DCT default behavior: Docker Content Trust is disabled by default, not enabled (UUID a1e36033)
- Fix single layer question: multi-stage builds don't squash to a single layer, --squash does (UUID 5f3ac20f)
- Fix volume-subpath: this flag doesn't exist in Docker, reformulated to use --mount syntax (UUID 7041ae89)

## Test plan
- [ ] Verify corrected answers are technically accurate
- [ ] Verify YAML lint passes
- [ ] Verify UUID uniqueness check passes